### PR TITLE
adapt to slightly changed mp4v2 API

### DIFF
--- a/src/in_mp4.c
+++ b/src/in_mp4.c
@@ -29,7 +29,7 @@
 /* fink error? */
 #define HAVE_IN_PORT_T 1
 #define HAVE_SOCKLEN_T 1
-#include <mp4.h>
+#include <mp4v2/mp4v2.h>
 #include <faad.h>
 
 /* -- data structures -- */
@@ -68,7 +68,7 @@ ices_mp4_open (input_stream_t* self, char* buf, size_t len)
   if (! self->filesize)
     return 1;
 
-  if ((mp4file = MP4Read(self->path, 0)) == MP4_INVALID_FILE_HANDLE)
+  if ((mp4file = MP4Read(self->path)) == MP4_INVALID_FILE_HANDLE)
     return 1;
 
   /* find audio stream */
@@ -135,7 +135,7 @@ ices_mp4_open (input_stream_t* self, char* buf, size_t len)
 errFAAC:
   faacDecClose(decoder);
 errMP4:
-  MP4Close(mp4file);
+  MP4Close(mp4file, 0);
 
   return -1;
 }
@@ -184,7 +184,7 @@ ices_mp4_close (input_stream_t* self)
   mp4_in_t* mp4_data = (mp4_in_t*) self->data;
 
   faacDecClose(mp4_data->decoder);
-  MP4Close(mp4_data->mp4file);
+  MP4Close(mp4_data->mp4file, 0);
   free (mp4_data);
 
   return 0;


### PR DESCRIPTION
I was getting failures compiling this on a recent Fedora and fixed them. Perhaps autoconf should recognize them and adapt the source accordingly, but then again old systems would mostly have an ices package available anyway while this repo is useful to get it back on more modern ones.